### PR TITLE
27 t028 create timestamp utility

### DIFF
--- a/src/lib/utils/timestamp.test.ts
+++ b/src/lib/utils/timestamp.test.ts
@@ -31,3 +31,88 @@ describe('Timestamp.ensureValidDate', () => {
             .toThrowError();
     })
 })
+
+
+describe('Timestamp.toISO', () => {
+    it('given valid date should return same date as toISOString', () => {
+        let d = new Date();
+        expect(Timestamp.toISO(d, false))
+            .toBe(d.toISOString());
+    })
+    it('valid date string should return date with same value', () => {
+        let dStr = '2026-03-18T18:02:42.112Z';
+        let d = new Date(dStr);
+        expect(Timestamp.toISO(dStr, false))
+            .toBe(d.toISOString());
+    })
+    it('null should return valid date', () => {
+        expect(Timestamp.toISO(null, false))
+            .toBeTypeOf('string')
+    })
+    it('undefined should return valid date', () => {
+        expect(Timestamp.toISO(undefined, false))
+            .toBeTypeOf('string')
+    })
+    
+    it('invalid date string should return now if set to quiet mode', () => {
+        expect(Timestamp.toISO('not-a-real-date', true))
+            .toBeTypeOf('string')
+    })
+    it('invalid date string should throw an error if quiet mode is off', () => {
+        expect(() => Timestamp.toISO('not-a-real-date', false))
+            .toThrowError();
+    })
+})
+
+
+describe('Timestamp.fromISO', () => {
+    it('given valid ISO date string should return same date as new Date()', () => {
+        let dStr = '2026-03-18T18:02:42.112Z';
+        let d = new Date(dStr);
+        expect(Timestamp.fromISO(dStr).getTime())
+            .toBe(d.getTime());
+    })
+    it('null should throw error because not a string', () => {
+        // @ts-ignore
+        expect(() => Timestamp.fromISO(null))
+            .toThrowError();
+    })
+    it('undefined should throw error because not a string', () => {
+        // @ts-ignore
+        expect(() => Timestamp.fromISO(undefined))
+            .toThrowError();
+    })
+    it('invalid date string should throw an error if quiet mode is off', () => {
+        expect(() => Timestamp.fromISO('not-a-real-date'))
+            .toThrowError();
+    })
+})
+
+
+describe('Timestamp.formatForDisplay', () => {
+    it('given date should return formatted string for right time zone', () => {
+        let d = new Date('2026-03-18T18:02:42.112Z');
+        expect(Timestamp.formatForDisplay(d, 'UTC'))
+            .toBe('Mar 18, 2026, 6:02 PM');
+    })
+    it('given date should return formatted string for right time zone', () => {
+        let d = new Date('2026-03-18T18:02:42.112Z');
+        expect(Timestamp.formatForDisplay(d, 'America/Denver'))
+            .toBe('Mar 18, 2026, 12:02 PM');
+    })
+    it('null should throw error because not a date', () => {
+        // @ts-ignore
+        expect(() => Timestamp.formatForDisplay(null, 'UTC'))
+            .toThrowError();
+    })
+    it('undefined should throw error because not a date', () => {
+        // @ts-ignore
+        expect(() => Timestamp.formatForDisplay(undefined, 'UTC'))
+            .toThrowError();
+    })
+    it('string should throw an error', () => {
+        // @ts-ignore
+        expect(() => Timestamp.formatForDisplay('2026-03-18T18:02:42.112Z'))
+            .toThrowError();
+    })
+})

--- a/src/lib/utils/timestamp.ts
+++ b/src/lib/utils/timestamp.ts
@@ -21,18 +21,21 @@ class Timestamp {
         }
         return d;
     }
-    static toISO(d: Date | string | null, quietFail:boolean = true): string {
+    static toISO(d: Date | string | null | undefined, quietFail:boolean = true): string {
         d = this.ensureValidDate(d, quietFail);
 
         return d.toISOString();
     }
-    static fromISO(s: string, quietFail:boolean = false): Date {
+    static fromISO(s: string): Date {
         if (typeof s !== 'string')
             throw new TypeError('fromISO must me given s of type: string');
 
-        return this.ensureValidDate(s, quietFail);
+        return this.ensureValidDate(s, false);
     }
-    static formatForDisplay(d:Date): string {
+    static formatForDisplay(d:Date, timeZone?:string): string {
+        if (!(d instanceof Date))
+            throw new TypeError('formatForDisplay must be given a Date object');
+
         d = this.ensureValidDate(d, false);
 
         return d.toLocaleString('en-US', {
@@ -41,7 +44,8 @@ class Timestamp {
             year: 'numeric',
             hour: 'numeric',
             minute: '2-digit',
-            hour12: true
+            hour12: true,
+            timeZone: timeZone ?? undefined
         });
     }
 }


### PR DESCRIPTION
added timestamp utility and corresponding unit tests.

added functions:
### Timestamp.ensureValidDate(date, quietFail)
1st arg: takes anything. If it can be parsed as a date, it does and returns a date.
2nd arg: must be a bool. if true, any invalid dates passed to the first arg are rejected as errors. If false, a  `new Date()` is returned and a warning put in the console, but no throwing of errors.

**Note:** all functions after this point use the above function internally to ensure dates are valid.

### Timestamp.toISO(date, quietFail = true)

### Timestamp.fromISO(date_string)
- will never quietly fail.

### Timestamp.formatForDisplay(date, timezone?)
- must be a valid date object, will never quietly fail.
- timezone is optional, will default to user's timezone.
  - (I mainly added this for my test script so that results were consistent.)