### PR TITLE
Add GPS utility to get geolocation

### DIFF
--- a/src/lib/utils/gps.ts
+++ b/src/lib/utils/gps.ts
@@ -1,0 +1,37 @@
+import { browser } from '$app/environment';
+
+function isGeolocationSupported() {
+  if (browser) {
+    if (navigator.geolocation) {
+      return true;
+    } else {
+      return false;
+    }
+  } else {
+    return false;
+  }
+}
+export async function getGeolocation() {
+  if (!isGeolocationSupported()) {
+    return null;
+  }
+  return new Promise<{ latitude: number; longitude: number; accuracy: number } | null>(
+    (resolve) => {
+      navigator.geolocation.getCurrentPosition(
+        (position) => {
+          resolve({
+            latitude: position.coords.latitude,
+            longitude: position.coords.longitude,
+            accuracy: position.coords.accuracy
+          });
+        },
+        (error) => {
+          resolve(null);
+        },
+        {
+          timeout: 10000
+        }
+      );
+    }
+  );
+}


### PR DESCRIPTION
Introduce a new utility src/lib/utils/gps.ts that provides isGeolocationSupported and getGeolocation. getGeolocation checks SvelteKit's browser environment, uses the Geolocation API with a 10s timeout, and returns a Promise resolving to { latitude, longitude, accuracy } or null if unsupported or on error.